### PR TITLE
Add option to force enable an app

### DIFF
--- a/setup-nextcloud-app/action.yml
+++ b/setup-nextcloud-app/action.yml
@@ -4,10 +4,9 @@ inputs:
   app:
     description: 'App name to test'
     required: true
-    default: 'null'
   check-code:
     description: 'Check app code'
-    required: true
+    required: false
     default: 'false'
   force:
     description: 'Force enable'

--- a/setup-nextcloud-app/action.yml
+++ b/setup-nextcloud-app/action.yml
@@ -4,11 +4,15 @@ inputs:
   app:
     description: 'App name to test'
     required: true
-    default: null
+    default: 'null'
   check-code:
     description: 'Check app code'
     required: true
-    default: false
+    default: 'false'
+  force:
+    description: 'Force enable'
+    required: false
+    default: 'false'
 runs:
   using: 'node12'
   main: 'main.js'

--- a/setup-nextcloud-app/main.js
+++ b/setup-nextcloud-app/main.js
@@ -4,8 +4,8 @@ const exec = require('@actions/exec')
 async function main() {
     try {
         const app       = core.getInput("app", {required: true})
-        const check     = core.getInput("check-code", {required: true})
-        const force     = core.getInput("force", {required: false})
+        const check     = (core.getInput("check-code", {required: false}) == 'true')
+        const force     = (core.getInput("force", {required: false}) == 'true')
         const serverDir = '../server'
 
         await exec.exec("mkdir", ["-p",`${serverDir}/apps/${app}`])

--- a/setup-nextcloud-app/main.js
+++ b/setup-nextcloud-app/main.js
@@ -5,13 +5,19 @@ async function main() {
     try {
         const app       = core.getInput("app", {required: true})
         const check     = core.getInput("check-code", {required: true})
+        const force     = core.getInput("force", {required: false})
         const serverDir = '../server'
 
         await exec.exec("mkdir", ["-p",`${serverDir}/apps/${app}`])
         await exec.exec("cp", ["-R", "./", `${serverDir}/apps/${app}`])
 
         process.chdir(serverDir)
-        await exec.exec("./occ", ["app:enable", app])
+
+        if (force) {
+            await exec.exec("./occ", ["-f", "app:enable", app])
+        }else {
+            await exec.exec("./occ", ["app:enable", app])
+        }
 
         if (check) {
             await exec.exec("./occ", ["app:check-code", app])

--- a/setup-nextcloud-app/main.js
+++ b/setup-nextcloud-app/main.js
@@ -13,11 +13,13 @@ async function main() {
 
         process.chdir(serverDir)
 
+        var args = ["app:enable", app]
+
         if (force) {
-            await exec.exec("./occ", ["-f", "app:enable", app])
-        }else {
-            await exec.exec("./occ", ["app:enable", app])
+            args.push("-f")
         }
+
+        await exec.exec("./occ", args)
 
         if (check) {
             await exec.exec("./occ", ["app:check-code", app])


### PR DESCRIPTION
This is useful to enable apps on pre-release versions that an app doesn't officially support yet.
News for example was already enabled for 21 for a long time, before we actually checked it.

With this users can set force: true and install the app anyway, then fix the possible comparability errors